### PR TITLE
FIX: Add get_caller_fqn() function

### DIFF
--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,2 +1,9 @@
+import sys
+
+collect_ignore = ["setup.py"]
+if sys.version_info[0] < 3:
+    collect_ignore.append("test_fqn_decorators_asynchronous.py")
+
+
 def pytest_configure():
     pass

--- a/tox.ini
+++ b/tox.ini
@@ -13,12 +13,6 @@ deps =
     -rrequirements/requirements-base.txt
     -rrequirements/requirements-testing.txt
 
-[testenv:py27]
-setenv =
-    PYTEST_ADDOPTS = --ignore tests/test_fqn_decorators_asynchronous.py
-deps =
-    {[testenv]deps}
-
 [testenv:lint]
 basepython = python3.5
 commands = flake8 decorators tests --exclude=fqn_decorators/__init__.py


### PR DESCRIPTION
This function will be necessary for other KPN libraries, e.g. timeexecution.